### PR TITLE
2.0.0 pbcs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,18 +17,16 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-         <version>3.4.5</version>
+        <version>3.4.5</version>
     </parent>
-
 
     <properties>
         <java.version>17</java.version>
-	<spring.version>6.2.11</spring.version>      
+        <spring.version>6.2.11</spring.version>
         <snakeyaml.version>2.3</snakeyaml.version>
         <kotlin.version>2.1.0</kotlin.version>
         <spring.restdocs.version>3.0.3</spring.restdocs.version>
-    <!-- Centralize protobuf version so it can be updated easily -->
-    <protobuf.version>4.28.2</protobuf.version>
+        <protobuf.version>4.28.2</protobuf.version>
     </properties>
 
     <dependencyManagement>
@@ -40,11 +38,19 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <!-- Netty BOM: ensures all Netty modules use the same (safe) version -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>4.1.126.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
     <dependencies>
-        <!-- Spring Boot -->
+        <!-- Logging -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
@@ -169,9 +175,9 @@
             <artifactId>gson</artifactId>
             <scope>compile</scope>
         </dependency>
-        <dependency>  
-			<groupId>com.github.ben-manes.caffeine</groupId>  
-			<artifactId>caffeine</artifactId>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.errorprone</groupId>
@@ -192,7 +198,6 @@
             <version>3.3.0</version>
         </dependency>
         <!-- Apache Tomcat -->
-        <!-- Apache Tomcat (explicitly pin to 11.0.10 as required) -->
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
@@ -242,20 +247,21 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- Netty: version managed by netty-bom -->
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
-            <version>4.1.126.Final</version>
         </dependency>
+        <!-- Neo4j Java Driver -->
         <dependency>
             <groupId>org.neo4j.driver</groupId>
             <artifactId>neo4j-java-driver</artifactId>
             <version>5.28.2</version>
             <exclusions>
-				<exclusion>
-					<groupId>io.netty</groupId>
-					<artifactId>netty-handler</artifactId>
-				</exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-handler</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -273,56 +279,53 @@
             <groupId>org.opensearch.client</groupId>
             <artifactId>opensearch-rest-client</artifactId>
             <version>2.11.1</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.apache.httpcomponents</groupId>
-					<artifactId>httpclient</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.httpcomponents</groupId>
-					<artifactId>httpcore</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.httpcomponents</groupId>
-					<artifactId>httpcore-nio</artifactId>
-				</exclusion>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpcore</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpcore-nio</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
-                <!-- Exclude protobuf so we can control version explicitly if needed -->
                 <exclusion>
                     <groupId>com.google.protobuf</groupId>
                     <artifactId>protobuf-java</artifactId>
                 </exclusion>
-			</exclusions>
+            </exclusions>
         </dependency>
-		<dependency>
-			<groupId>org.apache.httpcomponents</groupId>
-			<artifactId>httpclient</artifactId>
-			<version>4.5.13</version>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.13</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
             </exclusions>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.httpcomponents</groupId>
-			<artifactId>httpcore-nio</artifactId>
-			<version>4.4.16</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.httpcomponents</groupId>
-			<artifactId>httpcore</artifactId>
-			<version>4.4.16</version>
-		</dependency>
-		<dependency>
-			<groupId>org.opensearch.client</groupId>
-			<artifactId>opensearch-rest-high-level-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore-nio</artifactId>
+            <version>4.4.16</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>4.4.16</version>
+        </dependency>
+        <dependency>
+            <groupId>org.opensearch.client</groupId>
+            <artifactId>opensearch-rest-high-level-client</artifactId>
             <version>2.11.1</version>
             <exclusions>
                 <exclusion>
@@ -337,13 +340,12 @@
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j-api</artifactId>
                 </exclusion>
-                <!-- Exclude protobuf so we can manage / upgrade it directly -->
                 <exclusion>
                     <groupId>com.google.protobuf</groupId>
                     <artifactId>protobuf-java</artifactId>
                 </exclusion>
             </exclusions>
-		</dependency>
+        </dependency>
         <!-- AWS Java SDK -->
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -245,7 +245,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
-            <version>4.1.125.Final</version>
+            <version>4.1.126.Final</version>
         </dependency>
         <dependency>
             <groupId>org.neo4j.driver</groupId>


### PR DESCRIPTION
CVE-2025-58057 fixed by forcing dependancies to use netty 4.1.126.Final