### PR TITLE
2.0.0 enrollment period and study period sliders fix

### DIFF
--- a/src/main/resources/yaml/es_indices_popsci.yml
+++ b/src/main/resources/yaml/es_indices_popsci.yml
@@ -26,43 +26,42 @@ Indices:
       participant_maximum_age_upper_bound:
         type: integer
     cypher_query: "
-      MATCH (study:study)
-      OPTIONAL MATCH (study)<-[:associated_with]-(participant:participant)
-      SET study.study_ending_year = replace(toString(study.study_ending_year), ' ', '')
-      SET study.study_ending_year = CASE
-          WHEN toLower(trim(toString(study.study_ending_year))) CONTAINS 'ongoing' THEN '3000'
-          ELSE study.study_ending_year
-      END
+        MATCH (study:study)
+          OPTIONAL MATCH (study)<-[:associated_with]-(participant:participant)
+        
+        // Clean up study ending year for all studies
+        SET study.study_ending_year = replace(toString(study.study_ending_year), ' ', '')
+        SET study.study_ending_year = CASE
+            WHEN toLower(trim(toString(study.study_ending_year))) CONTAINS 'ongoing' THEN '3000'
+            ELSE study.study_ending_year
+        END
 
-      // Clean up enrollment ending year  
-      SET study.enrollment_ending_year = replace(toString(study.enrollment_ending_year), ' ', '')
-      SET study.enrollment_ending_year = CASE
-          WHEN study.enrollment_ending_year = 'null' THEN 'Ongoing' 
-          ELSE COALESCE(toString(study.enrollment_ending_year), 'Ongoing')
-      END
+        // Clean up enrollment ending year for all studies
+        SET study.enrollment_ending_year = replace(toString(study.enrollment_ending_year), ' ', '')
+        SET study.enrollment_ending_year = CASE
+            WHEN study.enrollment_ending_year = 'null' THEN 'Ongoing' 
+            ELSE COALESCE(toString(study.enrollment_ending_year), 'Ongoing')
+        END
 
-      WITH study, 
-          max(participant.age_at_enrollment / 365.25) AS study_max_age,
-          min(participant.age_at_enrollment / 365.25) AS study_min_age
-
-      RETURN
-          study.study_short_name as study_short_name,
-          max(toInteger(study.number_of_participants)) as number_of_participant_upper_bound,
-          min(toInteger(study.number_of_participants)) as number_of_participant_lower_bound,
-          min(toInteger(study.enrollment_beginning_year)) as                       enrollment_beginning_year_lower_bound,
-          CASE
-                WHEN study.enrollment_ending_year = 'Ongoing' THEN 3000 
-                ELSE COALESCE(toInteger(study.enrollment_ending_year), 3000)
-      END as enrollment_ending_year_upper_bound,
-      min(toInteger(study.study_beginning_year)) as study_beginning_year_lower_bound,
-      max(toInteger(study.study_ending_year)) as study_ending_year_upper_bound,
-      toInteger(round(min(study_min_age))) as participant_minimum_age,
-      toInteger(round(max(study_max_age))) as participant_maximum_age_upper_bound"
-  # study_demographics
-  # Purpose:
-  #   Supplies demographic tab data for the study detail tab
-  #   Build per-study demographic aggregates (race, sex, ethnicity), age-band distributions,
-  #   and summary metadata (enrollment/study years, participant age stats). Used for demographics panels.
+        RETURN
+            'global_max_bounds' as study_short_name,
+            max(toInteger(study.number_of_participants)) as number_of_participant_upper_bound,
+            min(toInteger(study.number_of_participants)) as number_of_participant_lower_bound,
+            min(toInteger(study.enrollment_beginning_year)) as enrollment_beginning_year_lower_bound,
+            max(CASE 
+              WHEN study.enrollment_ending_year = 'Ongoing' THEN 3000 
+              ELSE toInteger(study.enrollment_ending_year) 
+            END) as enrollment_ending_year_upper_bound,
+            min(toInteger(study.study_beginning_year)) as study_beginning_year_lower_bound,
+            max(toInteger(study.study_ending_year)) as study_ending_year_upper_bound,
+            min(toInteger(round(participant.age_at_enrollment / 365.25))) as participant_minimum_age,
+            max(toInteger(round(participant.age_at_enrollment / 365.25))) as participant_maximum_age_upper_bound
+      "
+  # # study_demographics
+  # # Purpose:
+  # #   Supplies demographic tab data for the study detail tab
+  # #   Build per-study demographic aggregates (race, sex, ethnicity), age-band distributions,
+  # #   and summary metadata (enrollment/study years, participant age stats). Used for demographics panels.
   - index_name: study_demographics
     type: neo4j
     # type mapping for each property of the index
@@ -812,7 +811,7 @@ Indices:
           digital_object_id:
             type: keyword
           pubmed_id:
-            type: integer
+            type: keyword
           publication_record_id:
             type: keyword
       associated_links:
@@ -844,7 +843,7 @@ Indices:
         year_of_publication: study_pub.year_of_publication,
         journal_citation: study_pub.journal_citation,
         digital_object_id:study_pub.digital_object_id,
-        pubmed_id:toInteger(study_pub.pubmed_id),
+        pubmed_id:COALESCE(toInteger(study_pub.pubmed_id), ' '),
         publication_record_id:study_pub.publication_record_id
        }) as publication,
         Collect(DISTINCT{

--- a/src/main/resources/yaml/es_indices_popsci.yml
+++ b/src/main/resources/yaml/es_indices_popsci.yml
@@ -729,10 +729,10 @@ Indices:
           ELSE toInteger(data_collection.data_collection_category_annotation_count)
         END as valid_count,
         data_collection
-          MATCH (study)<-[:associated_with]-(study_person:study_personnel)
-          MATCH (study)<-[:associated_with]-(data:data_file)
-          MATCH (study)<-[:associated_with]-(country:study_country)
-          MATCH (study)<-[:associated_with]-(state:study_state_province_territory)
+          OPTIONAL MATCH (study)<-[:associated_with]-(study_person:study_personnel)
+          OPTIONAL MATCH (study)<-[:associated_with]-(data:data_file)
+          OPTIONAL MATCH (study)<-[:associated_with]-(country:study_country)
+          OPTIONAL MATCH (study)<-[:associated_with]-(state:study_state_province_territory)
           SET study.study_ending_year = replace(toString(study.study_ending_year), ' ', '')
           SET study.study_ending_year = CASE
             WHEN toLower(trim(study.study_ending_year)) CONTAINS 'ongoing' THEN REPLACE(toLower(trim(study.study_ending_year)),study.study_ending_year, '3000')

--- a/src/main/resources/yaml/es_indices_popsci.yml
+++ b/src/main/resources/yaml/es_indices_popsci.yml
@@ -396,7 +396,7 @@ Indices:
           optional MATCH (study)<-[:associated_with]-(state:study_state_province_territory)
             optional MATCH (study)<-[:associated_with]-(neoplasm:primary_diagnosis)
              OPTIONAL MATCH (study)<-[:associated_with]-(data_collection:data_collection)
-              WHERE toInteger(data_collection.data_collection_category_annotation_count) <> 0 and data_collection.data_collection_category_annotation_count is not null
+             WHERE toInteger(data_collection.data_collection_category_annotation_count) <> 0 and data_collection.data_collection_category_annotation_count is not null and data_collection.data_collection_category <> 'Sexual Orientation and Gender Identity'
            SET study.study_ending_year = replace(toString(study.study_ending_year), ' ', '')
             SET study.study_ending_year = CASE
             WHEN toLower(trim(toString(study.study_ending_year))) CONTAINS 'ongoing' THEN REPLACE(toLower(trim(toString(study.study_ending_year))),study.study_ending_year, '3000')
@@ -438,8 +438,7 @@ Indices:
                 collect(DISTINCT{
                 group: study.study_short_name, 
                 subjects: study.cancer_diagnosis_primary_site_count
-          }) as study_cancer_diagnosis_primary_site_count
-     "
+          }) as study_cancer_diagnosis_primary_site_count "
   - index_name: data_volume_query
     type: neo4j
     # type mapping for each property of the index
@@ -593,10 +592,10 @@ Indices:
       race_group as race,
       sex_group as sex  
        "
-  # study_tab
-  # Purpose:
-  #   Main study-level index used for tabular study listings. Combines participant breakdowns,
-  #   study metadata, data collection category counts and file UUIDs for display and filtering.
+  # # study_tab
+  # # Purpose:
+  # #   Main study-level index used for tabular study listings. Combines participant breakdowns,
+  # #   study metadata, data collection category counts and file UUIDs for display and filtering.
   - index_name: study_tab
     type: neo4j
     mapping:
@@ -691,10 +690,10 @@ Indices:
       data_file_uuid:
         type: keyword
 
-      #    - UNWIND participant.race
-      #    - split pipe-delimited values, normalize and trim
-      #    - count tokens per study and collect as participant_races
-      #     this is done for sex, ethnicity and races
+  #     #    - UNWIND participant.race
+  #     #    - split pipe-delimited values, normalize and trim
+  #     #    - count tokens per study and collect as participant_races
+  #     #     this is done for sex, ethnicity and races
     cypher_query: "
            optional MATCH (study:study)<-[:associated_with]-(participant:participant) 
           UNWIND participant.race AS race_raw

--- a/src/main/resources/yaml/es_indices_popsci.yml
+++ b/src/main/resources/yaml/es_indices_popsci.yml
@@ -26,26 +26,38 @@ Indices:
       participant_maximum_age_upper_bound:
         type: integer
     cypher_query: "
-       MATCH (study:study)<-[:associated_with]-(participant:participant)
-      WITH toInteger(round(max(participant.age_at_enrollment / 365.25))) AS study_max_age, toInteger(round(min(participant.age_at_enrollment / 365.25))) AS study_min_age
-      WITH collect(study_max_age) AS max_ages_per_study, collect(study_min_age) AS min_ages_per_study
       MATCH (study:study)
-      MATCH (participant:participant)
+      OPTIONAL MATCH (study)<-[:associated_with]-(participant:participant)
       SET study.study_ending_year = replace(toString(study.study_ending_year), ' ', '')
-            SET study.study_ending_year = CASE
-            WHEN toLower(trim(toString(study.study_ending_year))) CONTAINS 'ongoing' THEN REPLACE(toLower(trim(toString(study.study_ending_year))),study.study_ending_year, '3000')
-            ELSE study.study_ending_year
-            END
+      SET study.study_ending_year = CASE
+          WHEN toLower(trim(toString(study.study_ending_year))) CONTAINS 'ongoing' THEN '3000'
+          ELSE study.study_ending_year
+      END
+
+      // Clean up enrollment ending year  
+      SET study.enrollment_ending_year = replace(toString(study.enrollment_ending_year), ' ', '')
+      SET study.enrollment_ending_year = CASE
+          WHEN study.enrollment_ending_year = 'null' THEN 'Ongoing' 
+          ELSE COALESCE(toString(study.enrollment_ending_year), 'Ongoing')
+      END
+
+      WITH study, 
+          max(participant.age_at_enrollment / 365.25) AS study_max_age,
+          min(participant.age_at_enrollment / 365.25) AS study_min_age
+
       RETURN
-        study.study_short_name as study_short_name,
-        max(study.number_of_participants) as number_of_participant_upper_bound,
-        min(study.number_of_participants) as number_of_participant_lower_bound,
-        min(study.enrollment_beginning_year) as enrollment_beginning_year_lower_bound,
-        max(study.enrollment_ending_year) as enrollment_ending_year_upper_bound,
-        min(study.study_beginning_year) as study_beginning_year_lower_bound,
-        max(study.study_ending_year) as study_ending_year_upper_bound,
-        study.participant_minimum_age as participant_minimum_age,
-        study.participant_maximum_age as participant_maximum_age_upper_bound"
+          study.study_short_name as study_short_name,
+          max(toInteger(study.number_of_participants)) as number_of_participant_upper_bound,
+          min(toInteger(study.number_of_participants)) as number_of_participant_lower_bound,
+          min(toInteger(study.enrollment_beginning_year)) as                       enrollment_beginning_year_lower_bound,
+          CASE
+                WHEN study.enrollment_ending_year = 'Ongoing' THEN 3000 
+                ELSE COALESCE(toInteger(study.enrollment_ending_year), 3000)
+      END as enrollment_ending_year_upper_bound,
+      min(toInteger(study.study_beginning_year)) as study_beginning_year_lower_bound,
+      max(toInteger(study.study_ending_year)) as study_ending_year_upper_bound,
+      toInteger(round(min(study_min_age))) as participant_minimum_age,
+      toInteger(round(max(study_max_age))) as participant_maximum_age_upper_bound"
   # study_demographics
   # Purpose:
   #   Supplies demographic tab data for the study detail tab
@@ -128,7 +140,7 @@ Indices:
     cypher_query: "
                 
     
-             MATCH (study:study)<-[:associated_with]-(participant:participant)
+            optional MATCH (study:study)<-[:associated_with]-(participant:participant)
 
         UNWIND participant.race AS race_raw
         UNWIND split(toLower(race_raw), '|') AS race_group
@@ -141,7 +153,7 @@ Indices:
         }) AS participant_races,study
 
 
-        MATCH (study)<-[:associated_with]-(participant:participant)
+       optional MATCH (study)<-[:associated_with]-(participant:participant)
         UNWIND participant.sex AS sex_raw
         UNWIND split(toLower(sex_raw), '|') AS sex_group
         WITH participant_races, trim(sex_group) as sex_group, count(*) AS sex_group_count
@@ -151,8 +163,8 @@ Indices:
         WITH participant_races, collect(DISTINCT {
             group: sex_group,
             subjects: sex_group_count
-        }) AS participant_sexes,study 
-        MATCH (study)<-[:associated_with]-(participant:participant)
+        }) AS participant_sexes,study
+       optional MATCH (study)<-[:associated_with]-(participant:participant)
         UNWIND participant.ethnicity AS ethnicity_raw
         UNWIND split(toLower(ethnicity_raw), '|') AS ethnicity_group
         WITH participant_races, participant_sexes, trim(ethnicity_group) as ethnicity_group, count(*) AS ethnicity_group_count
@@ -164,7 +176,7 @@ Indices:
         ,study
 
 
-        MATCH (study)<-[:associated_with]-(participant:participant)
+       optional MATCH (study)<-[:associated_with]-(participant:participant)
 
         WITH toInteger(participant.age_at_enrollment / 365.25) AS age_in_years,participant_races,participant_sexes,participant_ethnicities
         ,study
@@ -179,7 +191,7 @@ Indices:
         WITH toString(age_band_start) + ' to ' + toString(age_band_end)  AS age_group_label,participant_count,age_band_start,participant_races, participant_sexes,participant_ethnicities
         ,study
         ORDER BY age_group_label
-        MATCH (study)<-[:associated_with]-(participant:participant)
+        optional MATCH (study)<-[:associated_with]-(participant:participant)
  
 
         RETURN
@@ -197,18 +209,18 @@ Indices:
               study.study_design as study_design,
               toString(study.enrollment_beginning_year) as enrollment_beginning_year,
               toInteger(study.enrollment_ending_year) as enrollment_ending_year,
-              toInteger(study.enrollment_beginning_year) + ' - ' + toInteger(study.enrollment_ending_year)  as enrollment_period,
+              study.enrollment_period as enrollment_period,
               study.study_beginning_year as study_beginning_year,
               toInteger(study.study_ending_year) as study_ending_year,
-              toInteger(study.study_beginning_year) + ' - ' + COALESCE(study.study_ending_year,'On Going') as study_period,
+              toString(study.study_beginning_year) + ' - ' + 
+              CASE 
+                WHEN study.study_ending_year = '3000' THEN 'On Going'
+                ELSE COALESCE(toString(study.study_ending_year), 'On Going')
+              END as study_period,
               study.biospecimen_collection as biospecimen_collection,
               study.study_status as study_status,
               COLLECT(DISTINCT
-              CASE
-                WHEN study.study_short_name = 'PBCS' THEN 'Not available'
-                WHEN study.dbgap_accession_id IS NULL THEN 'N/A'
-                ELSE study.dbgap_accession_id
-              END
+               study.dbgap_accession_id
             ) as dbgap_accession_id,
 
               toInteger(study.number_of_participants) as number_of_participants,
@@ -248,12 +260,12 @@ Indices:
     # Cypher query will be used to retrieve data from Neo4j, and index into Elasticsearch
     cypher_query:
        " 
-        MATCH (study:study)<-[:associated_with]-(participant:participant)
+       optional MATCH (study:study)<-[:associated_with]-(participant:participant)
         WITH count(participant) as cancer_diagnosis_disease_morphology_count,
         participant.cancer_diagnosis_disease_morphology as cancer_diagnosis_disease_morphology,
         participant.`ICD-O-3 Code_disease_morphology` as code_morphology,
         study
-        MATCH (study)<-[:associated_with]-(participant:participant)
+        optional MATCH (study)<-[:associated_with]-(participant:participant)
         WITH count(participant) as cancer_diagnosis_primary_site_count,
          participant.cancer_diagnosis_primary_site as cancer_diagnosis_primary_site,
         cancer_diagnosis_disease_morphology,
@@ -347,7 +359,7 @@ Indices:
    # TODO FIX THE DBGAP TO ACCEPT NULL VALUES WITHOUT REPEATING IN A LIST AND CRASHING
     cypher_query:
           " 
-         MATCH (study:study)<-[:associated_with]-(participant:participant)
+          optional MATCH (study:study)<-[:associated_with]-(participant:participant)
           UNWIND participant.race AS race_raw
           UNWIND split(toLower(race_raw), '|') AS race_group
           WITH trim(race_group) AS race_group,study
@@ -357,7 +369,7 @@ Indices:
           study
 
 
-          MATCH (study)<-[:associated_with]-(participant:participant)
+         optional MATCH (study)<-[:associated_with]-(participant:participant)
           UNWIND participant.sex AS sex_raw
           UNWIND split(toLower(sex_raw), '|') AS sex_group
              WITH trim(sex_group) AS sex_group
@@ -369,7 +381,7 @@ Indices:
           COLLECT(DISTINCT sex_group) as sex_group
           
          
-          MATCH (study)<-[:associated_with]-(participant:participant)
+          optional MATCH (study)<-[:associated_with]-(participant:participant)
           UNWIND participant.ethnicity AS ethnicity_raw
           UNWIND split(toLower(ethnicity_raw), '|') AS ethnicity_group
           WITH  trim(ethnicity_group) as ethnicity_group, collect(DISTINCT study.study_short_name) AS study_count, race_group,
@@ -404,7 +416,7 @@ Indices:
                 Collect(distinct(neoplasm.primary_diagnosis_disease_term)) as primary_diagnosis_disease_term,
                 toString(study.enrollment_beginning_year) as enrollment_beginning_year,
                 toInteger(study.enrollment_ending_year) as enrollment_ending_year,
-                toInteger(study.enrollment_beginning_year) + ' - ' + toInteger(study.enrollment_ending_year)  as enrollment_period,
+                study.enrollment_period as enrollment_period,
                 toInteger(study.study_beginning_year) as study_beginning_year,
                 toInteger(study.study_ending_year) as study_ending_year,
                 study.participant_maximum_age as study_participant_maximum_age,
@@ -413,15 +425,11 @@ Indices:
                 study.participant_minimum_age as study_participant_minimum_age,
                 COLLECT(DISTINCT(data_collection.data_collection_category)) as data_collection_category,
                 toInteger(study.number_of_participants) as number_of_participants,
-                toInteger(study.study_beginning_year) + ' - ' + COALESCE(toInteger(study.study_ending_year),'On Going') as study_period,
+                study.study_period as study_period, 
                 study.biospecimen_collection as biospecimen_collection,
                 study.study_status as study_status,
                 COLLECT(DISTINCT
-              CASE
-                WHEN study.study_short_name = 'PBCS' THEN 'Not available'
-                WHEN study.dbgap_accession_id IS NULL THEN 'N/A'
-                ELSE study.dbgap_accession_id
-              END
+                study.dbgap_accession_id
             ) as dbgap_accession_id,
                 Collect(distinct(country.study_country)) as study_country,
                 Collect(distinct(state.study_state_province_territory)) as  study_state_province_territory,
@@ -506,7 +514,7 @@ Indices:
       #    - Collect them as a list for the front end to interpret
       #     this is done for sex, ethnicity and races
     cypher_query: "
-            MATCH (study:study)<-[:associated_with]-(participant:participant)
+          optional MATCH (study:study)<-[:associated_with]-(participant:participant)
           UNWIND participant.race AS race_raw
           UNWIND split(toLower(race_raw), '|') AS race_group
           WITH trim(race_group) AS race_group,study
@@ -516,7 +524,7 @@ Indices:
           study
 
 
-          MATCH (study)<-[:associated_with]-(participant:participant)
+          optional MATCH (study)<-[:associated_with]-(participant:participant)
           UNWIND participant.sex AS sex_raw
           UNWIND split(toLower(sex_raw), '|') AS sex_group
              WITH trim(sex_group) AS sex_group
@@ -528,7 +536,7 @@ Indices:
           COLLECT(DISTINCT sex_group) as sex_group
           
          
-          MATCH (study)<-[:associated_with]-(participant:participant)
+          optional MATCH (study)<-[:associated_with]-(participant:participant)
           UNWIND participant.ethnicity AS ethnicity_raw
           UNWIND split(toLower(ethnicity_raw), '|') AS ethnicity_group
           WITH  trim(ethnicity_group) as ethnicity_group, collect(DISTINCT study.study_short_name) AS study_count, race_group,
@@ -689,7 +697,7 @@ Indices:
       #    - count tokens per study and collect as participant_races
       #     this is done for sex, ethnicity and races
     cypher_query: "
-            MATCH (study:study)<-[:associated_with]-(participant:participant) 
+           optional MATCH (study:study)<-[:associated_with]-(participant:participant) 
           UNWIND participant.race AS race_raw
           UNWIND split(toLower(race_raw), '|') AS race_group
           WITH trim(race_group) as race_group, count(*) AS race_group_count,study
@@ -697,7 +705,7 @@ Indices:
               group: race_group,
               subjects: race_group_count
           }) AS participant_races,study, Collect(DISTINCT race_group) as race_group
-          MATCH (study)<-[:associated_with]-(participant:participant)
+          optional MATCH (study)<-[:associated_with]-(participant:participant)
           UNWIND participant.sex AS sex_raw
           UNWIND split(toLower(sex_raw), '|') AS sex_group
           WITH participant_races, trim(sex_group) as sex_group, count(*) AS sex_group_count,study,race_group
@@ -705,7 +713,7 @@ Indices:
               group: sex_group,
               subjects: sex_group_count
           }) AS participant_sexes,study,race_group,Collect(DISTINCT sex_group) as sex_group
-          MATCH (study)<-[:associated_with]-(participant:participant)
+          optional MATCH (study)<-[:associated_with]-(participant:participant)
           UNWIND participant.ethnicity AS ethnicity_raw
           UNWIND split(toLower(ethnicity_raw), '|') AS ethnicity_group
           WITH participant_races, participant_sexes, trim(ethnicity_group) as ethnicity_group, count(*) AS ethnicity_group_count,study,sex_group,race_group
@@ -723,10 +731,10 @@ Indices:
           ELSE toInteger(data_collection.data_collection_category_annotation_count)
         END as valid_count,
         data_collection
-          OPTIONAL MATCH (study)<-[:associated_with]-(study_person:study_personnel)
-          OPTIONAL MATCH (study)<-[:associated_with]-(data:data_file)
-          OPTIONAL MATCH (study)<-[:associated_with]-(country:study_country)
-          OPTIONAL MATCH (study)<-[:associated_with]-(state:study_state_province_territory)
+          MATCH (study)<-[:associated_with]-(study_person:study_personnel)
+          MATCH (study)<-[:associated_with]-(data:data_file)
+          MATCH (study)<-[:associated_with]-(country:study_country)
+          MATCH (study)<-[:associated_with]-(state:study_state_province_territory)
           SET study.study_ending_year = replace(toString(study.study_ending_year), ' ', '')
           SET study.study_ending_year = CASE
             WHEN toLower(trim(study.study_ending_year)) CONTAINS 'ongoing' THEN REPLACE(toLower(trim(study.study_ending_year)),study.study_ending_year, '3000')
@@ -745,7 +753,7 @@ Indices:
             toInteger(study.number_of_participants) as number_of_participants,
             study.participant_minimum_age  + ' - '   + study.participant_maximum_age as participant_age_range,
             study.cancer_diagnosis_primary_site_list as cancer_diagnosis_primary_site_list,
-            toInteger(study.study_beginning_year) + ' - ' + COALESCE(study.study_ending_year,'On Going') as study_period,
+            study.study_period as study_period,
             participant_races,
             participant_sexes,
             participant_ethnicities,
@@ -754,17 +762,13 @@ Indices:
             sex_group as sex,
             toInteger(study.enrollment_beginning_year) as enrollment_beginning_year,
             toInteger(study.enrollment_ending_year) as enrollment_ending_year,
-            toString(toInteger(study.enrollment_beginning_year)) + ' - ' +  toString(toInteger(study.enrollment_ending_year))  as enrollment_period,
+            study.enrollment_period as enrollment_period,
             study.study_beginning_year as study_beginning_year,
             toInteger(study.study_ending_year) as study_ending_year,
             study.biospecimen_collection as biospecimen_collection,
             study.study_status as study_status,
             COLLECT(DISTINCT
-              CASE
-                WHEN study.study_short_name = 'PBCS' THEN 'Not available'
-                WHEN study.dbgap_accession_id IS NULL THEN 'N/A'
-                ELSE study.dbgap_accession_id
-              END
+              study.dbgap_accession_id
             ) as dbgap_accession_id,
             Collect(distinct(country.study_country)) as study_country,
             count(Distinct(country.study_country)) as number_of_countries,
@@ -808,7 +812,7 @@ Indices:
           digital_object_id:
             type: keyword
           pubmed_id:
-            type: keyword
+            type: integer
           publication_record_id:
             type: keyword
       associated_links:
@@ -840,6 +844,7 @@ Indices:
         year_of_publication: study_pub.year_of_publication,
         journal_citation: study_pub.journal_citation,
         digital_object_id:study_pub.digital_object_id,
+        pubmed_id:toInteger(study_pub.pubmed_id),
         publication_record_id:study_pub.publication_record_id
        }) as publication,
         Collect(DISTINCT{

--- a/src/main/resources/yaml/es_indices_popsci.yml
+++ b/src/main/resources/yaml/es_indices_popsci.yml
@@ -729,10 +729,10 @@ Indices:
           ELSE toInteger(data_collection.data_collection_category_annotation_count)
         END as valid_count,
         data_collection
-          OPTIONAL MATCH (study)<-[:associated_with]-(study_person:study_personnel)
-          OPTIONAL MATCH (study)<-[:associated_with]-(data:data_file)
-          OPTIONAL MATCH (study)<-[:associated_with]-(country:study_country)
-          OPTIONAL MATCH (study)<-[:associated_with]-(state:study_state_province_territory)
+          MATCH (study)<-[:associated_with]-(study_person:study_personnel)
+          MATCH (study)<-[:associated_with]-(data:data_file)
+          MATCH (study)<-[:associated_with]-(country:study_country)
+          MATCH (study)<-[:associated_with]-(state:study_state_province_territory)
           SET study.study_ending_year = replace(toString(study.study_ending_year), ' ', '')
           SET study.study_ending_year = CASE
             WHEN toLower(trim(study.study_ending_year)) CONTAINS 'ongoing' THEN REPLACE(toLower(trim(study.study_ending_year)),study.study_ending_year, '3000')
@@ -842,7 +842,7 @@ Indices:
         year_of_publication: study_pub.year_of_publication,
         journal_citation: study_pub.journal_citation,
         digital_object_id:study_pub.digital_object_id,
-        pubmed_id:COALESCE(toInteger(study_pub.pubmed_id), ' '),
+        pubmed_id:COALESCE(toInteger(study_pub.pubmed_id), null),
         publication_record_id:study_pub.publication_record_id
        }) as publication,
         Collect(DISTINCT{

--- a/src/main/resources/yaml/es_indices_popsci.yml
+++ b/src/main/resources/yaml/es_indices_popsci.yml
@@ -730,10 +730,10 @@ Indices:
           ELSE toInteger(data_collection.data_collection_category_annotation_count)
         END as valid_count,
         data_collection
-          MATCH (study)<-[:associated_with]-(study_person:study_personnel)
-          MATCH (study)<-[:associated_with]-(data:data_file)
-          MATCH (study)<-[:associated_with]-(country:study_country)
-          MATCH (study)<-[:associated_with]-(state:study_state_province_territory)
+          OPTIONAL MATCH (study)<-[:associated_with]-(study_person:study_personnel)
+          OPTIONAL MATCH (study)<-[:associated_with]-(data:data_file)
+          OPTIONAL MATCH (study)<-[:associated_with]-(country:study_country)
+          OPTIONAL MATCH (study)<-[:associated_with]-(state:study_state_province_territory)
           SET study.study_ending_year = replace(toString(study.study_ending_year), ' ', '')
           SET study.study_ending_year = CASE
             WHEN toLower(trim(study.study_ending_year)) CONTAINS 'ongoing' THEN REPLACE(toLower(trim(study.study_ending_year)),study.study_ending_year, '3000')

--- a/src/main/resources/yaml/single_search_es.yml
+++ b/src/main/resources/yaml/single_search_es.yml
@@ -91,7 +91,7 @@ queries:
       type: object_array
   - name: minMaxBoundQuery
     index:
-      - min_max_bound_query_legacy
+      - min_max_bound_query
     filter:
       type: default
     result:


### PR DESCRIPTION
This Pull Request fixes the enrollment period and study period sliders. This required a refactoring of the min_max_bound_query to allow it to handle the new data. the Backend was using a legacy query until the work was done , thats now been replaced with the non legacy query. Also work was done to filter out Sexual Orientation and Gender Identity data collection category so the counts would line up across pages if included in the data. 

pumed_id was changed into an integer ,within the indices file to help load blank data, because the dataloader we are using will convert a blank numerical value as NaN and this then cannot be removed from the database without creating a new database and loading fresh data into that database. If I set it as an integer it would be loaded as a 0 which on the frontend can be filtered out. A numerical value cannot be blank , for IDs that have to be numeric they must be 0 or NaN .

[POPSCI-425](https://tracker.nci.nih.gov/browse/POPSCI-425)
[POPSCI-420](https://tracker.nci.nih.gov/browse/POPSCI-420) 