### PR TITLE
POPSCI-450: Update dependencies to address CVE vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
         <kotlin.version>2.1.0</kotlin.version>
         <spring.restdocs.version>3.0.3</spring.restdocs.version>
         <protobuf.version>4.28.2</protobuf.version>
+        <jackson.version>2.18.6</jackson.version>
     </properties>
 
     <dependencyManagement>
@@ -43,6 +44,14 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
                 <version>4.1.126.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- Jackson BOM: pins jackson-core and related modules to a non-vulnerable version -->
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -244,7 +253,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>2.15.2</version>
         </dependency>
         <!-- Neo4j Graphql -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -54,12 +54,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.24.3</version>
+            <version>2.25.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.24.3</version>
+            <version>2.25.3</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.logging.log4j</groupId>
@@ -208,7 +208,7 @@
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
-            <version>11.0.10</version>
+            <version>11.0.14</version>
             <scope>provided</scope>
         </dependency>
         <!-- JUnit -->
@@ -289,7 +289,7 @@
         <dependency>
             <groupId>org.opensearch.client</groupId>
             <artifactId>opensearch-rest-client</artifactId>
-            <version>2.11.1</version>
+            <version>2.19.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.httpcomponents</groupId>
@@ -337,7 +337,7 @@
         <dependency>
             <groupId>org.opensearch.client</groupId>
             <artifactId>opensearch-rest-high-level-client</artifactId>
-            <version>2.11.1</version>
+            <version>2.19.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>joda-time</groupId>


### PR DESCRIPTION
This PR updates several dependencies to remediate known CVEs and security advisories.

**Dependency updates**
- log4j-api/log4j-core: 2.24.3 → 2.25.3 (CVE-2025-68161, MEDIUM)
- tomcat-embed-core: 11.0.10 → 11.0.14 (CVE-2025-55752 HIGH, CVE-2025-66614 MEDIUM)
- opensearch-rest-client/opensearch-rest-high-level-client: 2.11.1 → 2.19.4 (CVE-2025-9624, HIGH)
- align Jackson to 2.18.6 to remediate GHSA-72hv-8253-57qq

**Verification**
- ✅ Build with fixes applied (no remaining vulnerabilities): https://github.com/CBIIT/crdc-popsci-backend/actions/runs/22731072721/job/65919974600#step:7:39
- ❌ Previous build with vulnerabilities: https://github.com/CBIIT/crdc-popsci-backend/actions/runs/22231229877/job/64311126003#step:7:43