### PR TITLE
POPSCI-464: Switch DCF API to production host

### DIFF
--- a/src/main/resources/yaml/es_indices_popsci.yml
+++ b/src/main/resources/yaml/es_indices_popsci.yml
@@ -573,7 +573,7 @@ Indices:
       data.data_file_description as data_file_description,
       data.data_file_format as data_file_format,
       data.data_file_compression_status as data_file_compression_status,
-      'drs://nci-crdc-staging.datacommons.io/dg.4DFC/' + data.data_file_uuid AS drs_uri,
+      'drs://nci-crdc.datacommons.io/dg.4DFC/' + data.data_file_uuid AS drs_uri,
       toInteger(study.number_of_participants) as number_of_participants,
       COLLECT(DISTINCT(data_collection.data_collection_category)) as data_collection_category,
       study.enrollment_beginning_year as enrollment_beginning_year,


### PR DESCRIPTION
This pull request makes a small but important update to the `src/main/resources/yaml/es_indices_popsci.yml` file. The change modifies the construction of the `drs_uri` to use the DCF production endpoint instead of the staging endpoint.

[POPSCI-464](https://tracker.nci.nih.gov/browse/POPSCI-464)