### PR TITLE
Bump tomcat-embed-core to 11.0.15 to fix Trivy vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
-            <version>11.0.14</version>
+            <version>11.0.15</version>
             <scope>provided</scope>
         </dependency>
         <!-- JUnit -->


### PR DESCRIPTION
Update pom.xml to use org.apache.tomcat.embed:tomcat-embed-core version 11.0.15 (previously 11.0.14). This PR fix CVE-2025-66614 vulnerability