### PR TITLE
Add Maven wrapper and bump Netty version

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,3 @@
+wrapperVersion=3.3.4
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <spring-framework.version>6.2.18</spring-framework.version>
         <spring.restdocs.version>3.0.1</spring.restdocs.version>
 	    <snakeyaml.version>2.0</snakeyaml.version>
-        <netty.version>4.1.133.Final</netty.version>
+        <netty.version>4.2.14.Final</netty.version>
     </properties>
 
     <dependencyManagement>
@@ -47,7 +47,7 @@
                 <artifactId>commons-logging</artifactId>
                 <version>1.2</version>
             </dependency>
-            <!-- Force Netty 4.1.133.Final to remediate CVE-2026-42583 -->
+            <!-- Force Netty 4.2.14.Final to remediate CVE-2026-42582/CVE-2026-42583 -->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>


### PR DESCRIPTION
Add .mvn/wrapper/maven-wrapper.properties to pin Maven wrapper (wrapperVersion=3.3.4, distributionUrl -> Apache Maven 3.9.9). Update project netty.version to 4.2.14.Final and adjust the dependency-management comment to note remediation for CVE-2026-42582/CVE-2026-42583.