### PR TITLE
data-collection

### DIFF
--- a/src/main/resources/yaml/es_indices_popsci.yml
+++ b/src/main/resources/yaml/es_indices_popsci.yml
@@ -687,6 +687,8 @@ Indices:
             type: keyword
           data_collection_category_annotation_count:
             type: integer
+          data_collection_category_assessed:
+            type: keyword
       data_file_uuid:
         type: keyword
 
@@ -775,6 +777,7 @@ Indices:
             Collect(DiSTINCT(data_collection.data_collection_category)) as data_collection_category,
             collect(Distinct{
             data_collection_category:data_collection.data_collection_category,
+            data_collection_category_assessed:data_collection.data_collection_category_assessed,
             data_collection_category_annotation_count:valid_count}) as data_collection,
             study.cancer_diagnosis_primary_site_count as primary_diagnosis_disease_count,
             COLLECT(DISTINCT(data.data_file_uuid)) as data_file_uuid     "
@@ -873,6 +876,7 @@ Indices:
       study.study_short_name as study_short_name,
       Collect(Distinct{
       data_collection_category:data_collection.data_collection_category,
+      data_collection_category_assessed:data_collection.data_collection_category_assessed,
       data_collection_category_annotation_count:toInteger(data_collection.data_collection_category_annotation_count)
       }) as data_collection
       "


### PR DESCRIPTION
This pull request updates the `es_indices_popsci.yml` configuration to support the new `data_collection_category_assessed` field in both the index mapping and related queries. The changes ensure that this field is properly indexed and included in query results for data collections.

Schema update:

* Added the `data_collection_category_assessed` field as a `keyword` type to the index mapping for improved data tracking.

Query updates:

* Modified aggregation queries to include the new `data_collection_category_assessed` field in the collected data for `data_collection`. [[1]](diffhunk://#diff-9f64e432587795d972e4f439011adce2a9de1ae24f0ec6efda5316b687ddcc2dR780) [[2]](diffhunk://#diff-9f64e432587795d972e4f439011adce2a9de1ae24f0ec6efda5316b687ddcc2dR879)