### PR TITLE
Security Patch: Fix 26+ OS and Java dependency CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update \
     libcap2 libgnutls30t64 sed dpkg curl libcurl4t64 \
     locales libc-bin libc6 libssl3t64 openssl libpng16-16t64 \
     libnghttp2-14 libssh-4 libudev1 libsystemd0 libgcrypt20 \
+    gzip tar perl-base wget libsqlite3-0 \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /usr/local/tomcat/webapps.dist \
     && rm -rf /usr/local/tomcat/webapps/ROOT \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ RUN apt-get update \
     locales libc-bin libc6 libssl3t64 openssl libpng16-16t64 \
     libnghttp2-14 libssh-4 libudev1 libsystemd0 libgcrypt20 \
     gzip tar perl-base wget libsqlite3-0 \
+    libgssapi-krb5-2 libk5crypto3 libkrb5-3 libkrb5support0 \
+    libpam-modules libpam-modules-bin libpam-runtime libpam0g \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /usr/local/tomcat/webapps.dist \
     && rm -rf /usr/local/tomcat/webapps/ROOT \

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <properties>
         <java.version>21</java.version>
-        <jackson.version>2.18.7</jackson.version>
+        <jackson.version>2.18.9</jackson.version>
         <kotlin.version>1.9.25</kotlin.version>
         <tomcat.version>11.0.22</tomcat.version>
         <lombok.version>1.18.34</lombok.version>
@@ -30,7 +30,7 @@
         <spring-framework.version>6.2.18</spring-framework.version>
         <spring.restdocs.version>3.0.1</spring.restdocs.version>
 	    <snakeyaml.version>2.0</snakeyaml.version>
-        <netty.version>4.2.14.Final</netty.version>
+        <netty.version>4.2.15.Final</netty.version>
     </properties>
 
     <dependencyManagement>
@@ -38,7 +38,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
-                <version>2.18.7</version>
+                <version>${jackson.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
This pull request updates the Docker image and project dependencies to improve compatibility and security. The main changes are the addition of several system libraries to the Docker image and the upgrade of key dependencies in `pom.xml`.

**Docker image improvements:**

* Added essential system libraries to the Docker image, including `gzip`, `tar`, `wget`, `libsqlite3-0`, and several Kerberos and PAM-related libraries, to improve compatibility and support for authentication and compression features.

**Dependency upgrades:**

* Upgraded `jackson.version` from `2.18.7` to `2.18.9` to include the latest bug fixes and security patches.
* Upgraded `netty.version` from `4.2.14.Final` to `4.2.15.Final` for improved network handling and security.
* Updated the `jackson-bom` dependency to use the new `${jackson.version}` property for consistency.