### PR TITLE
fix(security): upgrade Tomcat and harden OS packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update \
     locales libc-bin libc6 libssl3t64 openssl libpng16-16t64 \
     libnghttp2-14 libssh-4 libudev1 libsystemd0 libgcrypt20 \
     gzip tar perl-base wget libsqlite3-0 \
+    liblzma5 ncurses-base libncursesw6 libtinfo6 ncurses-bin \
     libgssapi-krb5-2 libk5crypto3 libkrb5-3 libkrb5support0 \
     libpam-modules libpam-modules-bin libpam-runtime libpam0g \
     && rm -rf /var/lib/apt/lists/* \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN mvn package -DskipTests
 FROM tomcat:11.0.23-jdk21-temurin AS fnl_base_image
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends unzip gosu \
+    && apt-get install -y --no-install-recommends unzip \
     && apt-get install -y --no-install-recommends --only-upgrade \
     libcap2 libgnutls30t64 sed dpkg curl libcurl4t64 \
     locales libc-bin libc6 libssl3t64 openssl libpng16-16t64 \
@@ -43,6 +43,7 @@ RUN mkdir /usr/local/tomcat/webapps/ROOT \
     && jar -xf ../ROOT.war \
     && rm ../ROOT.war
 
-COPY conf/entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+# Set ownership of writable dirs (already done above), then drop to non-root user
+RUN chown -R tomcat:tomcat /usr/local/tomcat/webapps
+USER tomcat
+ENTRYPOINT ["catalina.sh", "run"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY . .
 RUN mvn package -DskipTests
 
 # Production stage
-FROM tomcat:11.0.23-jdk21-temurin AS fnl_base_image
+FROM tomcat:11.0.24-jdk21-temurin AS fnl_base_image
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends unzip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY . .
 RUN mvn package -DskipTests
 
 # Production stage
-FROM tomcat:11.0.22-jdk21-temurin AS fnl_base_image
+FROM tomcat:11.0.23-jdk21-temurin AS fnl_base_image
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends unzip gosu \

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN mkdir /usr/local/tomcat/webapps/ROOT \
     && jar -xf ../ROOT.war \
     && rm ../ROOT.war
 
-# Set ownership of writable dirs (already done above), then drop to non-root user
+# Ensure writable dirs are owned by tomcat, then drop to non-root user
 RUN chown -R tomcat:tomcat /usr/local/tomcat/webapps
 USER tomcat
 ENTRYPOINT ["catalina.sh", "run"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ RUN apt-get update \
     liblzma5 ncurses-base libncursesw6 libtinfo6 ncurses-bin \
     libgssapi-krb5-2 libk5crypto3 libkrb5-3 libkrb5support0 \
     libpam-modules libpam-modules-bin libpam-runtime libpam0g \
+    libexpat1 zlib1g libp11-kit0 p11-kit p11-kit-modules \
+    libuuid1 libsmartcols1 libmount1 libblkid1 bsdutils util-linux \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /usr/local/tomcat/webapps.dist \
     && rm -rf /usr/local/tomcat/webapps/ROOT \

--- a/conf/entrypoint.sh
+++ b/conf/entrypoint.sh
@@ -1,10 +1,7 @@
 #!/bin/sh
 set -e
 
-# Fix ownership of volume-mounted paths so the non-root tomcat user can write to them
-chown -R tomcat:tomcat \
-    /usr/local/tomcat/logs \
-    /usr/local/tomcat/work \
-    /usr/local/tomcat/temp
-
-exec gosu tomcat catalina.sh run
+# This entrypoint is no longer used.
+# The container runs as the 'tomcat' user via the USER directive in the Dockerfile.
+# Kept for backward compatibility reference only.
+exec catalina.sh run

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <tomcat.version>11.0.22</tomcat.version>
         <lombok.version>1.18.34</lombok.version>
         <log4j2.version>2.25.4</log4j2.version>
-        <spring-framework.version>6.2.18</spring-framework.version>
+        <spring-framework.version>6.2.19</spring-framework.version>
         <spring.restdocs.version>3.0.1</spring.restdocs.version>
 	    <snakeyaml.version>2.0</snakeyaml.version>
         <netty.version>4.2.15.Final</netty.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <java.version>21</java.version>
         <jackson.version>2.18.9</jackson.version>
         <kotlin.version>1.9.25</kotlin.version>
-        <tomcat.version>11.0.23</tomcat.version>
+        <tomcat.version>11.0.24</tomcat.version>
         <lombok.version>1.18.34</lombok.version>
         <log4j2.version>2.25.4</log4j2.version>
         <spring-framework.version>6.2.19</spring-framework.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <java.version>21</java.version>
         <jackson.version>2.18.9</jackson.version>
         <kotlin.version>1.9.25</kotlin.version>
-        <tomcat.version>11.0.22</tomcat.version>
+        <tomcat.version>11.0.23</tomcat.version>
         <lombok.version>1.18.34</lombok.version>
         <log4j2.version>2.25.4</log4j2.version>
         <spring-framework.version>6.2.19</spring-framework.version>


### PR DESCRIPTION
This pull request updates dependencies and improves the security posture of the Docker image by removing the use of the `gosu` utility and running the container as the non-root `tomcat` user directly. It also upgrades Tomcat and Spring Framework versions for the application.

Dependency upgrades:

* Upgraded Tomcat from version `11.0.22` to `11.0.24` in both the Docker base image (`Dockerfile`) and Maven configuration (`pom.xml`). [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L17-R30) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L27-R30)
* Upgraded Spring Framework from `6.2.18` to `6.2.19` in `pom.xml`.

Container security and best practices:

* Removed installation and use of `gosu`; the container now uses the `USER tomcat` directive to run as a non-root user, improving security and simplifying the entrypoint. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L17-R30) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L45-R51)
* Updated the entrypoint to use `catalina.sh run` directly and set the correct ownership of the `webapps` directory for the `tomcat` user. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L45-R51) [[2]](diffhunk://#diff-235c4bb0d343a7441f7b0bf4e351b7ad71a36ad75e6169b8d096e6806ca21724L4-R7)
* Added several additional required system libraries to the Docker image for completeness and compatibility.