### PR TITLE
Handle multiple Piped UBERON codes for cancer_diagnosis_primary_site

### DIFF
--- a/src/main/resources/yaml/es_indices_popsci.yml
+++ b/src/main/resources/yaml/es_indices_popsci.yml
@@ -265,8 +265,8 @@ Indices:
         participant.`ICD-O-3 Code_disease_morphology` as code_morphology,
         study
         optional MATCH (study)<-[:associated_with]-(participant:participant)
-        UNWIND participant.cancer_diagnosis_primary_site AS cancer_diagnosis_primary_site_raw
-        UNWIND split(toLower(cancer_diagnosis_primary_site_raw), ',') AS cancer_diagnosis_primary_site_group
+        UNWIND coalesce(participant.cancer_diagnosis_primary_site, []) AS cancer_diagnosis_primary_site_raw
+        UNWIND [s IN split(toLower(cancer_diagnosis_primary_site_raw), ',') WHERE trim(s) <> ''] AS cancer_diagnosis_primary_site_group
         WITH trim(cancer_diagnosis_primary_site_group) as cancer_diagnosis_primary_site,
         count(*) as cancer_diagnosis_primary_site_count,
         cancer_diagnosis_disease_morphology,

--- a/src/main/resources/yaml/es_indices_popsci.yml
+++ b/src/main/resources/yaml/es_indices_popsci.yml
@@ -260,13 +260,20 @@ Indices:
     cypher_query:
        " 
         optional MATCH (study:study)<-[:associated_with]-(participant:participant)
-        WITH count(participant) as cancer_diagnosis_disease_morphology_count,
-        participant.cancer_diagnosis_disease_morphology as cancer_diagnosis_disease_morphology,
-        participant.`ICD-O-3 Code_disease_morphology` as code_morphology,
-        study
+        WITH study,
+        [s IN split(toLower(coalesce(participant.cancer_diagnosis_disease_morphology, '')), ' ^ ') WHERE trim(s) <> ''] AS cancer_diagnosis_disease_morphology_parts,
+        [s IN split(coalesce(participant.`ICD-O-3 Code_disease_morphology`, ''), ' ^ ') WHERE trim(s) <> ''] AS code_morphology_parts
+        UNWIND range(0, size(cancer_diagnosis_disease_morphology_parts) - 1) AS morphology_part_index
+        WITH study,
+        trim(cancer_diagnosis_disease_morphology_parts[morphology_part_index]) as cancer_diagnosis_disease_morphology,
+        CASE WHEN morphology_part_index < size(code_morphology_parts) THEN trim(code_morphology_parts[morphology_part_index]) ELSE null END as code_morphology
+        WITH study,
+        cancer_diagnosis_disease_morphology,
+        code_morphology,
+        count(*) as cancer_diagnosis_disease_morphology_count
         optional MATCH (study)<-[:associated_with]-(participant:participant)
         UNWIND coalesce(participant.cancer_diagnosis_primary_site, []) AS cancer_diagnosis_primary_site_raw
-        UNWIND [s IN split(toLower(cancer_diagnosis_primary_site_raw), ',') WHERE trim(s) <> ''] AS cancer_diagnosis_primary_site_group
+        UNWIND [s IN split(toLower(cancer_diagnosis_primary_site_raw), ' ^ ') WHERE trim(s) <> ''] AS cancer_diagnosis_primary_site_group
         WITH trim(cancer_diagnosis_primary_site_group) as cancer_diagnosis_primary_site,
         count(*) as cancer_diagnosis_primary_site_count,
         cancer_diagnosis_disease_morphology,

--- a/src/main/resources/yaml/es_indices_popsci.yml
+++ b/src/main/resources/yaml/es_indices_popsci.yml
@@ -265,8 +265,10 @@ Indices:
         participant.`ICD-O-3 Code_disease_morphology` as code_morphology,
         study
         optional MATCH (study)<-[:associated_with]-(participant:participant)
-        WITH count(participant) as cancer_diagnosis_primary_site_count,
-         participant.cancer_diagnosis_primary_site as cancer_diagnosis_primary_site,
+        UNWIND participant.cancer_diagnosis_primary_site AS cancer_diagnosis_primary_site_raw
+        UNWIND split(toLower(cancer_diagnosis_primary_site_raw), ',') AS cancer_diagnosis_primary_site_group
+        WITH trim(cancer_diagnosis_primary_site_group) as cancer_diagnosis_primary_site,
+        count(*) as cancer_diagnosis_primary_site_count,
         cancer_diagnosis_disease_morphology,
         cancer_diagnosis_disease_morphology_count,
         study,
@@ -359,7 +361,7 @@ Indices:
     cypher_query:
           " 
           optional MATCH (study:study)<-[:associated_with]-(participant:participant)
-          UNWIND participant.race AS race_raw
+          UNWIND coalesce(participant.race, []) AS race_raw
           UNWIND split(toLower(race_raw), '|') AS race_group
           WITH trim(race_group) AS race_group,study
 
@@ -369,7 +371,7 @@ Indices:
 
 
          optional MATCH (study)<-[:associated_with]-(participant:participant)
-          UNWIND participant.sex AS sex_raw
+          UNWIND coalesce(participant.sex, []) AS sex_raw
           UNWIND split(toLower(sex_raw), '|') AS sex_group
              WITH trim(sex_group) AS sex_group
              ,race_group,study
@@ -381,7 +383,7 @@ Indices:
           
          
           optional MATCH (study)<-[:associated_with]-(participant:participant)
-          UNWIND participant.ethnicity AS ethnicity_raw
+          UNWIND coalesce(participant.ethnicity, []) AS ethnicity_raw
           UNWIND split(toLower(ethnicity_raw), '|') AS ethnicity_group
           WITH  trim(ethnicity_group) as ethnicity_group, collect(DISTINCT study.study_short_name) AS study_count, race_group,
           sex_group,study
@@ -397,11 +399,11 @@ Indices:
             optional MATCH (study)<-[:associated_with]-(neoplasm:primary_diagnosis)
              OPTIONAL MATCH (study)<-[:associated_with]-(data_collection:data_collection)
              WHERE data_collection.data_collection_category_assessed is not null and data_collection.data_collection_category <> 'Sexual Orientation and Gender Identity' and  data_collection.data_collection_category_assessed = 'Yes'
-           SET study.study_ending_year = replace(toString(study.study_ending_year), ' ', '')
-            SET study.study_ending_year = CASE
-            WHEN toLower(trim(toString(study.study_ending_year))) CONTAINS 'ongoing' THEN REPLACE(toLower(trim(toString(study.study_ending_year))),study.study_ending_year, '3000')
-            ELSE study.study_ending_year
-            END
+          WITH study, race_group, sex_group, ethnicity_group, country, state, neoplasm, data_collection,
+            CASE
+              WHEN toLower(trim(replace(toString(study.study_ending_year), ' ', ''))) CONTAINS 'ongoing' THEN '3000'
+              ELSE replace(toString(study.study_ending_year), ' ', '')
+            END AS normalized_study_ending_year
           RETURN
           
             study.study_name as study_name,
@@ -413,11 +415,11 @@ Indices:
                 study.study_design as study_design,
                 study.cancer_diagnosis_primary_site_list as cancer_diagnosis_primary_site_list,
                 Collect(distinct(neoplasm.primary_diagnosis_disease_term)) as primary_diagnosis_disease_term,
-                toString(study.enrollment_beginning_year) as enrollment_beginning_year,
+                toInteger(study.enrollment_beginning_year) as enrollment_beginning_year,
                 toInteger(study.enrollment_ending_year) as enrollment_ending_year,
                 study.enrollment_period as enrollment_period,
                 toInteger(study.study_beginning_year) as study_beginning_year,
-                toInteger(study.study_ending_year) as study_ending_year,
+                toInteger(normalized_study_ending_year) as study_ending_year,
                 study.participant_maximum_age as study_participant_maximum_age,
                 study.participant_mean_age as study_participant_mean_age,
                 study.participant_median_age as study_participant_median_age,
@@ -513,7 +515,7 @@ Indices:
       #     this is done for sex, ethnicity and races
     cypher_query: "
           optional MATCH (study:study)<-[:associated_with]-(participant:participant)
-          UNWIND participant.race AS race_raw
+          UNWIND coalesce(participant.race, []) AS race_raw
           UNWIND split(toLower(race_raw), '|') AS race_group
           WITH trim(race_group) AS race_group,study
 
@@ -523,7 +525,7 @@ Indices:
 
 
           optional MATCH (study)<-[:associated_with]-(participant:participant)
-          UNWIND participant.sex AS sex_raw
+          UNWIND coalesce(participant.sex, []) AS sex_raw
           UNWIND split(toLower(sex_raw), '|') AS sex_group
              WITH trim(sex_group) AS sex_group
              ,race_group,study
@@ -535,7 +537,7 @@ Indices:
           
          
           optional MATCH (study)<-[:associated_with]-(participant:participant)
-          UNWIND participant.ethnicity AS ethnicity_raw
+          UNWIND coalesce(participant.ethnicity, []) AS ethnicity_raw
           UNWIND split(toLower(ethnicity_raw), '|') AS ethnicity_group
           WITH  trim(ethnicity_group) as ethnicity_group, collect(DISTINCT study.study_short_name) AS study_count, race_group,
           sex_group,study
@@ -552,11 +554,11 @@ Indices:
       optional MATCH (study)<-[:associated_with]-(country:study_country)
       optional MATCH (study)<-[:associated_with]-(state:study_state_province_territory)
 
-      SET study.study_ending_year = replace(toString(study.study_ending_year), ' ', '')
-      SET study.study_ending_year = CASE
-      WHEN toLower(trim(toString(study.study_ending_year))) CONTAINS 'ongoing' THEN REPLACE(toLower(trim(toString(study.study_ending_year))),study.study_ending_year, '3000')
-      ELSE study.study_ending_year
-      END
+      WITH study, data, data_collection, country, state, ethnicity_group, race_group, sex_group,
+      CASE
+        WHEN toLower(trim(replace(toString(study.study_ending_year), ' ', ''))) CONTAINS 'ongoing' THEN '3000'
+        ELSE replace(toString(study.study_ending_year), ' ', '')
+      END AS normalized_study_ending_year
       RETURN
 
       study.study_short_name as study_short_name,
@@ -582,7 +584,7 @@ Indices:
       study.participant_mean_age as study_participant_mean_age,
       study.participant_median_age as study_participant_median_age,
       study.participant_minimum_age as study_participant_minimum_age,
-      study.study_ending_year as study_ending_year,
+      normalized_study_ending_year as study_ending_year,
       study.study_beginning_year as study_beginning_year,
       study.study_status as study_status,
       study.cancer_diagnosis_primary_site_list as cancer_diagnosis_primary_site_list,
@@ -696,7 +698,7 @@ Indices:
   #     #     this is done for sex, ethnicity and races
     cypher_query: "
            optional MATCH (study:study)<-[:associated_with]-(participant:participant) 
-          UNWIND participant.race AS race_raw
+          UNWIND coalesce(participant.race, []) AS race_raw
           UNWIND split(toLower(race_raw), '|') AS race_group
           WITH trim(race_group) as race_group, count(*) AS race_group_count,study
           WITH collect(DISTINCT {
@@ -704,7 +706,7 @@ Indices:
               subjects: race_group_count
           }) AS participant_races,study, Collect(DISTINCT race_group) as race_group
           optional MATCH (study)<-[:associated_with]-(participant:participant)
-          UNWIND participant.sex AS sex_raw
+          UNWIND coalesce(participant.sex, []) AS sex_raw
           UNWIND split(toLower(sex_raw), '|') AS sex_group
           WITH participant_races, trim(sex_group) as sex_group, count(*) AS sex_group_count,study,race_group
           WITH participant_races, collect(DISTINCT {
@@ -712,7 +714,7 @@ Indices:
               subjects: sex_group_count
           }) AS participant_sexes,study,race_group,Collect(DISTINCT sex_group) as sex_group
           optional MATCH (study)<-[:associated_with]-(participant:participant)
-          UNWIND participant.ethnicity AS ethnicity_raw
+          UNWIND coalesce(participant.ethnicity, []) AS ethnicity_raw
           UNWIND split(toLower(ethnicity_raw), '|') AS ethnicity_group
           WITH participant_races, participant_sexes, trim(ethnicity_group) as ethnicity_group, count(*) AS ethnicity_group_count,study,sex_group,race_group
           WITH participant_races,participant_sexes,collect(DISTINCT {
@@ -730,11 +732,12 @@ Indices:
           OPTIONAL MATCH (study)<-[:associated_with]-(data:file)
           OPTIONAL MATCH (study)<-[:associated_with]-(country:study_country)
           OPTIONAL MATCH (study)<-[:associated_with]-(state:study_state_province_territory)
-          SET study.study_ending_year = replace(toString(study.study_ending_year), ' ', '')
-          SET study.study_ending_year = CASE
-            WHEN toLower(trim(study.study_ending_year)) CONTAINS 'ongoing' THEN REPLACE(toLower(trim(study.study_ending_year)),study.study_ending_year, '3000')
-            ELSE study.study_ending_year
-          END
+          WITH study, participant_races, participant_sexes, participant_ethnicities, sex_group, race_group, ethnicity_group,
+          valid_count, data_collection, data, country, state,
+          CASE
+            WHEN toLower(trim(replace(toString(study.study_ending_year), ' ', ''))) CONTAINS 'ongoing' THEN '3000'
+            ELSE replace(toString(study.study_ending_year), ' ', '')
+          END AS normalized_study_ending_year
           RETURN 
             study.study_name as study_name,
             study.study_short_name as study_short_name,
@@ -759,7 +762,7 @@ Indices:
             toInteger(study.enrollment_ending_year) as enrollment_ending_year,
             study.enrollment_period as enrollment_period,
             study.study_beginning_year as study_beginning_year,
-            toInteger(study.study_ending_year) as study_ending_year,
+            toInteger(normalized_study_ending_year) as study_ending_year,
             study.biospecimen_collection as biospecimen_collection,
             study.study_status as study_status,
             COLLECT(DISTINCT
@@ -873,5 +876,7 @@ Indices:
       data_collection_category_assessed:data_collection.data_collection_category_assessed
       }) as data_collection
       "
+
+  
 
   


### PR DESCRIPTION
Fixes handling of multi-value and piped fields in the es_indices_popsci.yml Cypher queries, plus normalization of study year fields.
Ticket: [POPSCI-543](https://tracker.nci.nih.gov/browse/POPSCI-543)
Problem
1. cancer_diagnosis_primary_site delimiter conflict
Raw values use | as a separator between codes (e.g. uberon1223|uberon1224). After translation to human-readable labels, this becomes a comma-separated string (e.g. nose,mouth) so it can be split and counted per-participant, the same way we already do for race, ethnicity, and sex.
2. ICD-O code/label pairs get miscounted
ICD-O values can contain a | natively (e.g. separating multiple diagnosis codes), so we can't reuse , as the translated delimiter — it already appears inside ICD-O codes/labels. We use ^ instead.
More importantly, the code and its corresponding label must be split together, as paired units, not independently. If code and label lists are split separately, they get zipped incorrectly during counting. For example, given 8140/3|9691/3 (adenocarcinoma | follicular lymphoma), splitting the codes and labels independently causes mismatched pairings during aggregation — resulting in phantom combinations like "follicular lymphoma" being counted under code 8140/3, and inflated/incorrect totals for both real pairings.
Changes

Replaced UNWIND participant.race/sex/ethnicity with UNWIND coalesce(..., []) to prevent null/UNWIND errors when a field is missing.
Added split/trim logic on these fields for consistent grouping.
Added UNWIND + split(...) handling for cancer_diagnosis_primary_site so comma-separated entries are correctly exploded and counted individually.
Fixed ICD-O code/label pairing so codes and labels are split together as matched pairs, preventing cross-contamination between codes and labels during counting.
Centralized study.study_ending_year normalization into a new normalized_study_ending_year field:

Strips whitespace
Maps "ongoing" → "3000"
Cast via toInteger(normalized_study_ending_year) in the query return


Changed enrollment_beginning_year to toInteger for consistent typing with other year fields.