### PR TITLE
Add global search schema and ES mappings

### DIFF
--- a/src/main/resources/graphql/popsci-private-es.graphql
+++ b/src/main/resources/graphql/popsci-private-es.graphql
@@ -23,7 +23,6 @@ type GS_Model {
   property_description: String
   property_required: String
   property_type: String
-  value: String
   highlight: String
 }
 

--- a/src/main/resources/graphql/popsci-private-es.graphql
+++ b/src/main/resources/graphql/popsci-private-es.graphql
@@ -1,3 +1,55 @@
+type GlobalSearchResult {
+  study: [GS_Study]
+  study_count: Int
+
+  about_count: Int
+  about_page: [GS_About]
+
+  model_count: Int
+  model: [GS_Model]
+
+  gs_list: [GS_list]
+  model_search: [GS_Model_Search]
+}
+
+type GS_list {
+  autocomplete_list: String
+}
+
+type GS_Model {
+  type: String
+  node_name: String
+  property_name: String
+  property_description: String
+  property_required: String
+  property_type: String
+  value: String
+  highlight: String
+}
+
+type GS_About {
+  page: String
+  title: String
+  type: String
+  text: [String]
+}
+
+type GS_Model_Search {
+  node: String
+}
+
+type GS_Study {
+  study_name: String
+  study_short_name: String
+  study_participant_minimum_age: Int
+  study_participant_maximum_age: Int
+  study_design: String
+  number_of_participants: Int
+  cancer_type_count: Int
+}
+
+
+
 type SearchResult {
   numberOfStudies: Int
   numberOfDataCollectionCatagory: Int
@@ -372,6 +424,12 @@ type QueryType {
   dataCollectionPage(
     study_short_name: [String] = []
   ): [data_collection_page]
+
+  globalSearch(
+    input: String
+    first: Int = 10
+    offset: Int = 0
+  ): GlobalSearchResult
 
   minMaxBoundQuery: [minMaxBoundQuery]
 }

--- a/src/main/resources/yaml/es_indices_popsci.yml
+++ b/src/main/resources/yaml/es_indices_popsci.yml
@@ -945,6 +945,4 @@ Indices:
         type: keyword
       property_type:
         type: keyword
-      value_kw:
-        type: keyword
   

--- a/src/main/resources/yaml/es_indices_popsci.yml
+++ b/src/main/resources/yaml/es_indices_popsci.yml
@@ -1,9 +1,9 @@
 Indices:
-  # min_max_bound_query
-  # Purpose:
-  #   this is for the explore page so help make the sliders work 
-  #   Compute global min/max bounds across studies for participant counts, enrollment/study years,
-  #   and participant ages. Used to power range filters and min/max bounding queries in the UI.
+#   # min_max_bound_query
+#   # Purpose:
+#   #   this is for the explore page so help make the sliders work 
+#   #   Compute global min/max bounds across studies for participant counts, enrollment/study years,
+#   #   and participant ages. Used to power range filters and min/max bounding queries in the UI.
   - index_name: min_max_bound_query
     type: neo4j
     mapping:
@@ -340,6 +340,8 @@ Indices:
         type: keyword
       cancer_diagnosis_primary_site_list:
         type: keyword
+      cancer_diagnosis_disease_morphology_list:
+        type: keyword
       sex:
         type: keyword
       race:
@@ -411,6 +413,7 @@ Indices:
                 study.study_description as study_description,
                 study.study_type as study_type,
                 study.study_design as study_design,
+                study.cancer_diagnosis_disease_morphology_list as cancer_diagnosis_disease_morphology_list,
                 study.cancer_diagnosis_primary_site_list as cancer_diagnosis_primary_site_list,
                 Collect(distinct(neoplasm.primary_diagnosis_disease_term)) as primary_diagnosis_disease_term,
                 toString(study.enrollment_beginning_year) as enrollment_beginning_year,
@@ -873,5 +876,65 @@ Indices:
       data_collection_category_assessed:data_collection.data_collection_category_assessed
       }) as data_collection
       "
+  - index_name: about_page
+    type: about_file
+    # type mapping for each property of the index
+    mapping:
+      page:
+        type: keyword
+      title:
+        type: keyword
+      primaryContentImage:
+        type: text
+      content:
+        type: object
+    
 
+  - index_name: model_nodes
+    type: model
+    subtype: node
+    # type mapping for each property of the index
+    mapping:
+      node:
+        type: keyword
+      node_kw:
+        type: keyword
+  #Handles information stored in model file
+
+  - index_name: model_properties
+    type: model
+    subtype: property
+    # type mapping for each property of the index
+    mapping:
+      node:
+        type: keyword
+      property:
+        type: keyword
+      property_kw:
+        type: keyword
+      property_description:
+        type: keyword
+      property_required:
+        type: keyword
+      property_type:
+        type: keyword
+  #Handles information stored in model file
+
+  - index_name: model_values
+    type: model
+    subtype: value
+    # type mapping for each property of the index
+    mapping:
+      node:
+        type: keyword
+      property:
+        type: keyword
+      property_description:
+        type: keyword
+      property_required:
+        type: keyword
+      property_type:
+        type: keyword
+      value_kw:
+        type: keyword
   

--- a/src/main/resources/yaml/global_search_es.yml
+++ b/src/main/resources/yaml/global_search_es.yml
@@ -52,7 +52,7 @@ queries:
               type: wildcard
               caseInsensitive: true
           typedSearch:
-            - field: cancer_diagnosis_primary_site
+            - field: cancer_type_count
               type: term
               option: integer
         result:

--- a/src/main/resources/yaml/global_search_es.yml
+++ b/src/main/resources/yaml/global_search_es.yml
@@ -1,170 +1,64 @@
 queries:
   - name: globalSearch
     returnFields:
-      - name: subjects
+      - name: study
         index:
-          - subjects
+          - global_stats_bar
         filter:
           type: global
-          defaultSortField: subject_id_num
+          defaultSortField: study_short_name
           searches:
-            - field: subject_id
+            - field: study_short_name
               type: wildcard
               caseInsensitive: true
-            - field: diagnosis_gs
+            - field: study_design
               type: wildcard
               caseInsensitive: true
-          typedSearch:
-            - field: age_at_index
-              type: term
-              option: integer
-        result:
-          type: global
-      - name: subject_count
-        index:
-          - subjects
-        filter:
-          type: global
-          defaultSortField: subject_id_num
-          searches:
-            - field: subject_id
+            - field: primary_diagnosis_disease_term
               type: wildcard
               caseInsensitive: true
-            - field: diagnosis_gs
+            - field: cancer_diagnosis_primary_site_list
+              type: wildcard
+              caseInsensitive: true
+            - field: cancer_diagnosis_disease_morphology_list
               type: wildcard
               caseInsensitive: true
           typedSearch:
-            - field: age_at_index
+            - field: cancer_type_count
               type: term
               option: integer
-        result:
-          type: int_total_count
-
-      - name: samples
-        index:
-          - samples
-        filter:
-          type: global
-          defaultSortField: subject_id_num
-          searches:
-            - field: sample_id_gs
-              type: wildcard
-            - field: sample_anatomic_site_gs
-              type: wildcard
-            - field: tissue_type_gs
-              type: wildcard
-        result:
-          type: global
-      - name: sample_count
-        index:
-          - samples
-        filter:
-          type: global
-          defaultSortField: subject_id_num
-          searches:
-            - field: sample_id_gs
-              type: wildcard
-            - field: sample_anatomic_site_gs
-              type: wildcard
-            - field: tissue_type_gs
-              type: wildcard
-        result:
-          type: int_total_count
-
-      - name: programs
-        index:
-          - programs
-        filter:
-          type: global
-          defaultSortField: program_id_kw
-          searches:
-            - field: program_id
-              type: wildcard
-            - field: program_code
-              type: wildcard
-            - field: program_name
-              type: wildcard
-        result:
-          type: global
-      - name: program_count
-        index:
-          - programs
-        filter:
-          type: global
-          defaultSortField: program_id_kw
-          searches:
-            - field: program_id
-              type: wildcard
-            - field: program_code
-              type: wildcard
-            - field: program_name
-              type: wildcard
-        result:
-          type: int_total_count
-
-      - name: studies
-        index:
-          - studies
-        filter:
-          type: global
-          defaultSortField: study_id_kw
-          searches:
-            - field: study_id
-              type: wildcard
-            - field: study_name
-              type: wildcard
-            - field: study_type
-              type: wildcard
         result:
           type: global
       - name: study_count
         index:
-          - studies
+          - global_stats_bar
         filter:
           type: global
-          defaultSortField: study_id_kw
+          defaultSortField: study_short_name
           searches:
-            - field: study_id
+            - field: study_short_name
               type: wildcard
-            - field: study_name
+              caseInsensitive: true
+            - field: study_design
               type: wildcard
-            - field: study_type
+              caseInsensitive: true
+            - field: primary_diagnosis_disease_term
               type: wildcard
+              caseInsensitive: true
+            - field: cancer_diagnosis_primary_site_list
+              type: wildcard
+              caseInsensitive: true
+            - field: cancer_diagnosis_disease_morphology_list
+              type: wildcard
+              caseInsensitive: true
+          typedSearch:
+            - field: cancer_diagnosis_primary_site
+              type: term
+              option: integer
         result:
           type: int_total_count
 
-      - name: files
-        index:
-          - files
-        filter:
-          type: global
-          defaultSortField: file_id_num
-          searches:
-            - field: file_id_gs
-              type: wildcard
-            - field: file_name
-              type: wildcard
-              caseInsensitive: true
-            - field: file_format_gs
-              type: wildcard
-        result:
-          type: global
-      - name: file_count
-        index:
-          - files
-        filter:
-          type: global
-          defaultSortField: file_id_num
-          searches:
-            - field: file_id_gs
-              type: wildcard
-            - field: file_name
-              type: wildcard
-              caseInsensitive: true
-            - field: file_format_gs
-              type: wildcard
-        result:
-          type: int_total_count
+      
 
       # About Page
       # Always Set offset= 0 and default-size=10000
@@ -173,6 +67,8 @@ queries:
           - about_page
         filter:
           type: global
+          defaultSortField: title
+          sortDirection: ASC
           selectedField: content.paragraph
           searches:
             - field: content.paragraph
@@ -180,6 +76,7 @@ queries:
         highlight:
           fields:
             - content.paragraph
+          fragmentSize: 25
           preTag: $
           postTag: $
         result:
@@ -209,20 +106,22 @@ queries:
           - model_values
           - model_nodes
         filter:
+          defaultSortField: node
+          sortDirection: ASC
           type: global
           searches:
-            - field: value.keyword
+            - field: value_kw
               type: wildcard
             - field: property_name
-              type: term
+              type: wildcard
             - field: property_type
               type: term
             - field: property_description
               type: wildcard
-            - field: node_name
+            - field: node
               type: term
           typedSearch:
-            - field: property_required
+            - field: node
               type: match
               option: boolean
         highlight:
@@ -231,8 +130,7 @@ queries:
             - property_description
             - property_type
             - property_required
-            - value
-            - node_name
+            - node
           fragmentSize: 1
         result:
           type: global_multi_models
@@ -245,10 +143,10 @@ queries:
         filter:
           type: global
           searches:
-            - field: value.keyword
+            - field: value_kw
               type: wildcard
             - field: property_name
-              type: term
+              type: wildcard
             - field: property_type
               type: term
             - field: property_description
@@ -265,8 +163,49 @@ queries:
             - property_description
             - property_type
             - property_required
-            - value
+            - value_kw
             - node_name
           fragmentSize: 1
         result:
           type: int_total_count
+      - name: gs_list
+        index:
+          - gs_list
+        filter:
+          type: global
+          searches:
+            - field: autocomplete_list
+              type: wildcard
+          typedSearch:
+            - field: autocomplete_list
+              type: term
+              option: integer
+        highlight:
+          fields:
+            - autocomplete_list
+          fragmentSize: 1
+        result:
+          type: global
+      - name: model_search
+        index:
+          - model_nodes
+        filter:
+          type: global
+          searches:
+            - field: node
+              type: wildcard
+            - field: node_kw
+              type: term
+          typedSearch:
+            - field: node
+              type: match
+              option: boolean
+        highlight:
+          fields:
+            - node
+            - node_kw
+          fragmentSize: 1
+        result:
+          type: global_multi_models
+
+      


### PR DESCRIPTION
Introduce a new `globalSearch` GraphQL surface with dedicated result types for studies, about content, model metadata, and autocomplete/model node lookups. Rework `global_search_es.yml` to target PopSci-specific indices (not legacy subject/sample/program/file indices), including updated search fields, sorting, highlights, and count queries. Extend Elasticsearch index definitions with `about_page`, `model_nodes`, `model_properties`, and `model_values`, and add study morphology data to the global stats index so study search can include morphology terms.

Tickets: 
[POPSCI-573](https://tracker.nci.nih.gov/browse/POPSCI-573)
[POPSCI-574](https://tracker.nci.nih.gov/browse/POPSCI-574)
[POPSCI-575](https://tracker.nci.nih.gov/browse/POPSCI-575)
[POPSCI-576](https://tracker.nci.nih.gov/browse/POPSCI-576)